### PR TITLE
[Infrastructure] Place login behind a feature flag

### DIFF
--- a/web/src/AppRoutes.tsx
+++ b/web/src/AppRoutes.tsx
@@ -84,7 +84,12 @@ function ScrollToTop() {
 const UnauthenticatedAppRoutes: React.FC = () => {
   return (
     <React.Fragment>
-      <Route exact path="/login" component={LoginPage} />
+      <ExperimentalRoute
+        featureKey={FeatureFlags.SIGN_UP}
+        exact
+        path="/login"
+        component={LoginPage}
+      />
       <ExperimentalRoute
         featureKey={FeatureFlags.SIGN_UP}
         exact


### PR DESCRIPTION
This PR puts the `/login` route behind a feature flag, so that users can't access it until we are officially launched. 