### PR TITLE
fix the countdown timer mounting issue

### DIFF
--- a/web/database-debug.log
+++ b/web/database-debug.log
@@ -1,0 +1,7 @@
+WARNING: An illegal reflective access operation has occurred
+WARNING: Illegal reflective access by io.netty.util.internal.ReflectionUtil (file:/Users/faraz.ahmad/.cache/firebase/emulators/firebase-database-emulator-v4.7.2.jar) to field sun.nio.ch.SelectorImpl.selectedKeys
+WARNING: Please consider reporting this to the maintainers of io.netty.util.internal.ReflectionUtil
+WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
+WARNING: All illegal access operations will be denied in a future release
+17:03:54.351 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
+17:03:54.573 [main] INFO com.firebase.server.forge.App$ - Listening at localhost:9000

--- a/web/src/components/RetroCountdownTimer.tsx
+++ b/web/src/components/RetroCountdownTimer.tsx
@@ -29,19 +29,20 @@ export function RetroCountdownTimer({ timer }: RetroCountdownTimerPropsT) {
       >
         {symbol}
       </SmallButton>
-
-      <SmallButton
-        style={{ boxShadow: "none", borderColor: "white" }}
-        onClick={timer.reset}
-      >
-        <Restart />
-      </SmallButton>
       <SmallButton
         style={{ boxShadow: "none", borderColor: "white", fontSize: "0.75em" }}
         onClick={timer.add1Min}
       >
         +1m
       </SmallButton>
+      {timer.isPaused ? (
+        <SmallButton
+          style={{ boxShadow: "none", borderColor: "white" }}
+          onClick={timer.reset}
+        >
+          <Restart />
+        </SmallButton>
+      ) : null}
     </div>
   );
 }

--- a/web/src/hooks/use-retro-countdown-timer.ts
+++ b/web/src/hooks/use-retro-countdown-timer.ts
@@ -67,17 +67,6 @@ export function useRetroCountdownTimer(retroId: Retro["id"]): RetroCountdownTime
     return;
   };
 
-  React.useEffect(() => {
-    const initialzeTimer = () => {
-      handleUpdate([
-        { key: "milliseconds", value: initialTime },
-        { key: "state", value: CountdownTimerState.CLOSED }
-      ]);
-    };
-    initialzeTimer();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   let milliseconds = countdownTimer?.milliseconds;
   React.useEffect(() => {
     if (milliseconds) {
@@ -129,6 +118,7 @@ export function useRetroCountdownTimer(retroId: Retro["id"]): RetroCountdownTime
     () => {
       const diff = Date.now() - countdownTimer?.startAt - serverTimeOffset;
       setTimeLeft((countdownTimer?.milliseconds || 0) - diff);
+
       if (timeLeft < 0) {
         window.clearInterval(intervalRef.current);
         handleChangeTime(0);
@@ -139,9 +129,16 @@ export function useRetroCountdownTimer(retroId: Retro["id"]): RetroCountdownTime
   );
 
   const isOpen = countdownTimer && countdownTimer.state !== CountdownTimerState.CLOSED;
+  const initializeTimer = () => {
+    handleUpdate([{ key: "milliseconds", value: initialTime }]);
+    setTimeLeft(initialTime);
+  };
   const handleToggleTimer = async () => {
     const nextState = isOpen ? CountdownTimerState.CLOSED : CountdownTimerState.PAUSED;
     await handleUpdate([{ key: "state", value: nextState }]);
+    if (nextState === CountdownTimerState.PAUSED) {
+      initializeTimer();
+    }
     handleTrack(AnalyticsEvent.RETRO_TIMER_TOGGLED, { nextState });
     return;
   };


### PR DESCRIPTION
timer was being reset every time a user refreshed the page because we were initializing on mount. now we only initialize when it's opened.