### PR TITLE
Add incognito setting to RetroSidePanel

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "yarn start",
-    "emulate": "firebase emulators:start --project dev",
+    "emulate": "firebase emulators:start --project prod",
     "start": "react-scripts start",
     "test": "react-scripts test",
     "build": "react-scripts build",

--- a/web/src/components/RetroBoard.tsx
+++ b/web/src/components/RetroBoard.tsx
@@ -19,6 +19,7 @@ import { RetroStateValues, RetroStateStatus } from "../hooks/use-retro-state";
 import { RetroItemModal } from "./RetroItemModal";
 import { WorkspaceUser, WorkspaceUsersMap } from "../types/workspace-user";
 import { AnalyticsEvent, useAnalyticsEvent } from "../hooks/use-analytics-event";
+import { EyeOffIcon } from "@heroicons/react/outline";
 
 interface RetroBoardProps {
   retroState: RetroStateValues;
@@ -222,6 +223,7 @@ export function RetroBoard({
                 type={columnType}
                 items={items}
                 users={users}
+                isIncognito={data?.isIncognito}
                 onClickAdd={() => handleOnClickAdd(columnType)}
                 onClickEdit={handleOnClickEdit}
                 onClickLike={onLikeItem}
@@ -240,6 +242,7 @@ interface RetroListProps {
   type: RetroColumn["type"];
   items: any[];
   users: WorkspaceUsersMap;
+  isIncognito?: boolean;
   onClickAdd: () => void;
   onClickLike: (input: any) => void;
   onClickUnlike: (input: any) => void;
@@ -251,6 +254,7 @@ export const RetroList: React.FC<RetroListProps> = ({
   type,
   items,
   users,
+  isIncognito,
   onClickAdd,
   onClickLike,
   onClickUnlike,
@@ -276,6 +280,7 @@ export const RetroList: React.FC<RetroListProps> = ({
                     key={item.id}
                     index={index}
                     author={users[item.createdByUserId]}
+                    isIncognito={isIncognito}
                     onClickLike={onClickLike}
                     onClickUnlike={onClickUnlike}
                     onClickEdit={() => onClickEdit(item)}
@@ -296,6 +301,7 @@ export const RetroListItem: React.FC<
   RetroItem & {
     index: number;
     author: WorkspaceUser;
+    isIncognito?: boolean;
     onClickLike: (input: any) => void;
     onClickUnlike: (input: any) => void;
     onClickEdit: () => void;
@@ -305,6 +311,7 @@ export const RetroListItem: React.FC<
   content,
   likedBy,
   likeCount,
+  isIncognito,
   author,
   createdByUserId,
   onClickLike,
@@ -314,6 +321,8 @@ export const RetroListItem: React.FC<
 }) => {
   const currentUser = useCurrentUser();
   const authAccount = currentUser.auth!;
+
+  const isAuthor = createdByUserId === authAccount.uid;
 
   const handleLikeItem = () => {
     const userId = currentUser!.data!.id;
@@ -338,24 +347,19 @@ export const RetroListItem: React.FC<
             {...provided.dragHandleProps}
           >
             <div className="flex content-center">
-              {/* {author && (
-                <UserAvatar
-                  displayName={author.userDisplayName || author.userEmail}
-                  photoURL={author.userPhotoURL}
-                  isAnonymous={false}
-                />
-              )} */}
-              <div>
-                <Linkify>
+              <Linkify>
+                {isIncognito && !isAuthor ? (
+                  <div className="flex items-center" title="Incognito item until lifted">
+                    <EyeOffIcon className="h-4 w-4 text-blue" />
+                  </div>
+                ) : (
                   <span>{content}</span>
-                </Linkify>
-              </div>
+                )}
+              </Linkify>
             </div>
 
             <div className="flex ml-2 items-center">
-              {createdByUserId === authAccount.uid && (
-                <EditButton onClick={onClickEdit} />
-              )}
+              {isAuthor && <EditButton onClick={onClickEdit} />}
               <LikeButton
                 likeCount={likeCount}
                 likedBy={likedBy}

--- a/web/src/components/RetroBoardSidePanel.tsx
+++ b/web/src/components/RetroBoardSidePanel.tsx
@@ -17,6 +17,7 @@ export function RetroBoardSidePanel({ isOpen, toggle }: any) {
 
   const name = state?.data?.name;
   const createdAt = moment(state?.data?.createdAt?.toDate()).format("YYYY-MM-DD");
+  const isIncognito = state?.data?.isIncognito;
 
   const updateRetro = useUpdateRetro();
   const trackEvent = useAnalyticsEvent();
@@ -28,7 +29,9 @@ export function RetroBoardSidePanel({ isOpen, toggle }: any) {
       // @ts-ignore
       name: event.target?.name?.value,
       // @ts-ignore
-      createdAt: firebase.firestore.Timestamp.fromDate(createdAtJSDate)
+      createdAt: firebase.firestore.Timestamp.fromDate(createdAtJSDate),
+      // @ts-ignore
+      isIncognito: event.target?.isIncognito?.checked
     });
     trackEvent(AnalyticsEvent.RETRO_UPDATED, {
       location: AnalyticsPage.RETRO_BOARD
@@ -118,6 +121,39 @@ export function RetroBoardSidePanel({ isOpen, toggle }: any) {
                           </div>
                         </div>
                       </div>
+                    </div>
+                    <div className="p-6">
+                      <fieldset>
+                        <legend className="text-sm font-medium text-gray">Privacy</legend>
+                        <div className="mt-2 space-y-5">
+                          <div className="relative flex items-start">
+                            <div className="flex items-center h-5">
+                              <input
+                                id="isIncognito"
+                                name="isIncognito"
+                                aria-describedby="isIncognito-description"
+                                type="checkbox"
+                                className="h-4 w-4 text-red border-gray"
+                                defaultChecked={isIncognito}
+                              />
+                            </div>
+                            <div className="pl-2 text-sm">
+                              <label
+                                htmlFor="isIncognito"
+                                className="font-bold text-white"
+                              >
+                                Incognito
+                              </label>
+                              <p
+                                id="isIncognito-description"
+                                className="text-gray text-xs"
+                              >
+                                Hide what people are writing during brainstorm.
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                      </fieldset>
                     </div>
                   </div>
                   <div className="flex-shrink-0 px-4 py-4 flex justify-end">

--- a/web/src/types/retro.ts
+++ b/web/src/types/retro.ts
@@ -17,6 +17,7 @@ export interface Retro {
   createdAt?: TODO;
   userIds: { [userId: string]: User["id"] };
   retroItemIds: { [retroItemId: string]: string };
+  isIncognito?: boolean;
   retroItemsData: {
     goodCount: number;
     badCount: number;


### PR DESCRIPTION
**Context**
closes #206 
Added a checkbox that allows the facilitator to enable/disable incognito mode. Incognito allows users to write their topics without others seeing what they are writing, until the facilitator lifts it.

You can see what you wrote, but you can't see other people's items.

<img width="594" alt="Screen Shot 2022-02-18 at 1 27 40 PM" src="https://user-images.githubusercontent.com/6789822/154741650-39c30c9a-ed8a-449b-9504-b35f491dacb9.png">
<img width="449" alt="Screen Shot 2022-02-18 at 1 28 20 PM" src="https://user-images.githubusercontent.com/6789822/154741653-53aeed44-976d-4d7b-bf7b-6ec6b672e6fe.png">
