### PR TITLE
Use NODE_ENV to check environment

### DIFF
--- a/web/functions/src/constants/is-prod.ts
+++ b/web/functions/src/constants/is-prod.ts
@@ -1,3 +1,1 @@
-import { projectIds } from "./project-ids";
-
-export const isProd = process.env.GCLOUD_PROJECT === projectIds.prod;
+export const isProd = process.env.NODE_ENV === "production";


### PR DESCRIPTION
**Context**
Before we had the Firebase local emulator, we had to use 2 separate Firebase projects to develop. We had a separate, hosted "dev" project that we used.

In order to check if you were on the dev or prod project, we compared the projectIds.

Now, since we have local development with the emulator, we don't use the "dev" project at all. So we can simply use the NODE_ENV environment variable to determine if we are coding locally or this is a build on prod.

**Expected result**
We should see notifications show up in the correct channel.